### PR TITLE
Fixed client port error

### DIFF
--- a/SingleThreaded/Client.java
+++ b/SingleThreaded/Client.java
@@ -10,7 +10,7 @@ import java.net.UnknownHostException;
 public class Client {
     
     public void run() throws UnknownHostException, IOException{
-        int port = 8090;
+        int port = 8010;
         InetAddress address = InetAddress.getByName("localhost");
         Socket socket = new Socket(address, port);
         PrintWriter toSocket = new PrintWriter(socket.getOutputStream(), true);


### PR DESCRIPTION
There was a bug in client port number which was supposed to be same as of server port number (ie 8010). Therefore it was not establishing connection with the server.


